### PR TITLE
Adding files to support command line testing of image creation

### DIFF
--- a/images/native-finalize.sh
+++ b/images/native-finalize.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# This is a finalize script that is run by clr-distro-factory to support
+# user's requirement for conversion / compression of images before exporting.
+# ex: <image_name>-finalize.sh
+
+set -e
+
+SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+
+if (( ${#} != 1 )); then
+    echo "${0}: Must receive exactly one file path." >&2
+    exit 1
+fi
+
+if [[ ! -s "${1}" ]]; then
+    echo "${0}: Invalid input: '${1}' is empty." >&2
+    exit 1
+fi
+
+file_ext="${1##*.}"
+
+if [[ "${file_ext}" == "iso" ]]; then
+    echo "${1}"
+else
+    "${SCRIPT_DIR}/task-compress-image.sh" "${1}" "${1}.xz" >&2
+    rm -rf "${@}" >&2
+    echo "${1}.xz"
+fi

--- a/images/native-post.sh
+++ b/images/native-post.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# This is a post install script that is run from the config after the image
+# has been created by clr-installer for images with special requirements
+# ex: <image_name>-post.sh
+
+set -e
+
+SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+
+# Delay booting to give user a change to change boot params
+${SCRIPT_DIR}/task-wait-to-boot.sh "${1}"

--- a/images/native.yaml
+++ b/images/native.yaml
@@ -27,7 +27,10 @@ targetMedia:
     type: part
 keyboard: us
 language: en_US.UTF-8
-bundles: [bootloader, os-core, os-core-update]
+iso: true
+keepImage: true
 telemetry: false
+bundles: [bootloader, os-core, os-core-update]
 kernel: kernel-native
 block-devices: [{name: native, file: native.img}]
+post-install: [{cmd: "${yamlDir}/native-post.sh ${chrootDir}"}]

--- a/images/task-compress-image.sh
+++ b/images/task-compress-image.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# This is a task script that can be executed to perform specific tasks
+# which are common between various images.
+# Task scripts can be called commonly from post & finalize scripts.
+# ex: task-<job_name>.sh
+
+set -e
+
+if (( ${#} < 1 )); then
+    echo "${0}: Insufficient number of arguments." >&2
+    exit 1
+fi
+
+if ! xz -q -T0 --stdout "${1}" > "${2:-${1}.xz}"; then
+    echo "${0}: Unable to compress file ${1}." >&2
+    exit 1
+fi

--- a/images/task-wait-to-boot.sh
+++ b/images/task-wait-to-boot.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# This is a task script that can be executed to perform specific tasks
+# which are common between various images.
+# Task scripts can be called commonly from post & finalize scripts.
+# ex: task-<job_name>.sh
+
+#!/bin/bash
+
+# Have the installer image wait 5 seconds before launch
+# Useful for users to change the boot command for debug
+
+echo "timeout 5" >> $1/boot/loader/loader.conf
+
+exit 0


### PR DESCRIPTION
Adding the below listed files for successful image creation and testing
on command line with make. This can be used as a basis for creating configs for different kinds of images with post & finalize scripts.

Signed-off-by: Vinay Potluri <vinay.potluri@intel.com>